### PR TITLE
Fix credit note generation fatal error

### DIFF
--- a/includes/Documents/CreditNote.php
+++ b/includes/Documents/CreditNote.php
@@ -101,9 +101,18 @@ class CreditNote extends OrderDocumentMethods {
 		do_action( 'wpo_wcpdf_init_document', $this );
 	}
 
-        public function exists() {
-                return ! empty( $this->data['number'] );
-        }
+       public function exists() {
+               return ! empty( $this->data['number'] );
+       }
+
+       /**
+        * Get the shop email address using the parent implementation.
+        *
+        * @return string
+        */
+       public function get_shop_email_address() {
+               return parent::get_shop_email_address();
+       }
 
        /**
         * Check if the credit note is allowed to be created.

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1484,7 +1484,7 @@ abstract class OrderDocument {
 
 		return apply_filters(
 			'wpo_wcpdf_get_shop_address',
-			wpo_wcpdf_format_address( $address ),
+                       \wpo_wcpdf_format_address( $address ),
 			$address,
 			$this
 		);


### PR DESCRIPTION
## Summary
- ensure global function call resolves correctly in `OrderDocument`
- expose `get_shop_email_address()` in `CreditNote` to avoid undefined method errors

## Testing
- `composer validate --no-check-all --strict`
- `php -l includes/Documents/OrderDocument.php`
- `php -l includes/Documents/CreditNote.php`


------
https://chatgpt.com/codex/tasks/task_e_687f5ba1ebec8328a7e2fdaf3e5a7129