### PR TITLE
Show shop details by default on credit notes

### DIFF
--- a/includes/Documents/CreditNote.php
+++ b/includes/Documents/CreditNote.php
@@ -328,6 +328,7 @@ class CreditNote extends OrderDocumentMethods {
 				'args'			=> array(
 					'option_name'		=> $option_name,
 					'id'				=> 'display_email',
+                                        'default'                       => 1,
 				)
 			),
 			array(
@@ -339,6 +340,7 @@ class CreditNote extends OrderDocumentMethods {
 				'args'			=> array(
 					'option_name'		=> $option_name,
 					'id'				=> 'display_phone',
+                                        'default'                       => 1,
 				)
 			),
 			array(
@@ -363,6 +365,7 @@ class CreditNote extends OrderDocumentMethods {
 				'args'			=> array(
 					'option_name'	=> $option_name,
 					'id'			=> 'display_date',
+                                        'default'                       => 'document_date',
 					'options' 		=> array(
 						''				=> __( 'No' , 'woocommerce-pdf-invoices-packing-slips' ),
 						'document_date'	=> __( 'Invoice Date' , 'woocommerce-pdf-invoices-packing-slips' ),


### PR DESCRIPTION
## Summary
- set default settings so email, phone, number and date appear on new credit notes

## Testing
- `php -l includes/Documents/CreditNote.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f946eee8083289313f177184f5b71