### PR TITLE
Implement invoice date sync for credit notes

### DIFF
--- a/includes/Documents/CreditNote.php
+++ b/includes/Documents/CreditNote.php
@@ -138,10 +138,33 @@ class CreditNote extends OrderDocumentMethods {
 	 *
 	 * @return mixed
 	 */
-        public function init_number() {
-                wcpdf_deprecated_function( 'init_number', '3.8.0', 'initiate_number' );
-                return $this->initiate_number();
-        }
+       public function init_number() {
+               wcpdf_deprecated_function( 'init_number', '3.8.0', 'initiate_number' );
+               return $this->initiate_number();
+       }
+
+      /**
+       * Initiate and set document date and display date.
+       *
+       * Reuse the invoice date when it exists for the order.
+       *
+       * @return void
+       */
+      public function initiate_date(): void {
+              if ( ! empty( $this->order ) ) {
+                      // credit notes on refunds should reference the parent order
+                      $order   = $this->is_refund( $this->order ) ? $this->get_refund_parent( $this->order ) : $this->order;
+                      $invoice = wcpdf_get_document( 'invoice', $order );
+
+                      if ( $invoice && $invoice->exists() ) {
+                              $this->set_date( $invoice->get_date() );
+                              $this->set_display_date( $invoice->get_display_date() );
+                              return;
+                      }
+              }
+
+              parent::initiate_date();
+      }
 
        /**
         * Initiate and set document number.


### PR DESCRIPTION
## Summary
- sync credit note date settings with related invoice

## Testing
- `php -l includes/Documents/CreditNote.php`


------
https://chatgpt.com/codex/tasks/task_e_687f946e67cc83288b4f8df0fee3ece4