### PR TITLE
Add dedicated credit note icon

### DIFF
--- a/assets/images/credit-note.svg
+++ b/assets/images/credit-note.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="4" y="1" width="16" height="20" rx="2" stroke="#6C45A6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="white"/>
+<path d="M0 4C0 3.44772 0.447715 3 1 3H7.5C8.05228 3 8.5 3.44772 8.5 4V6.5C8.5 7.05228 8.05228 7.5 7.5 7.5H1C0.447715 7.5 0 7.05228 0 6.5V4Z" fill="#ED1C24"/>
+<path d="M8 11H16" stroke="#6C45A6" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/includes/Documents/CreditNote.php
+++ b/includes/Documents/CreditNote.php
@@ -22,7 +22,7 @@ class CreditNote extends OrderDocumentMethods {
 		// set properties
 		$this->type  = 'credit-note';
 		$this->title = __( 'Credit Note', 'woocommerce-pdf-invoices-packing-slips' );
-		$this->icon  = WPO_WCPDF()->plugin_url() . "/assets/images/invoice.svg";
+               $this->icon  = WPO_WCPDF()->plugin_url() . "/assets/images/credit-note.svg";
 
 		// call parent constructor
 		parent::__construct( $order );


### PR DESCRIPTION
## Summary
- add new `credit-note.svg` asset for credit note documents
- point `CreditNote` document class to dedicated icon

## Testing
- `php -l includes/Documents/CreditNote.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68939a486018832899e8d186635612f3