### PR TITLE
Rebuild invoice XML exporter for direct streaming

### DIFF
--- a/includes/CustomXmlExporter.php
+++ b/includes/CustomXmlExporter.php
@@ -2,685 +2,619 @@
 namespace WPO\IPS;
 
 use DOMDocument;
-use WPO\IPS\Documents\OrderDocument;
 use WC_Abstract_Order;
+use WPO\IPS\Documents\BulkDocument;
+use WPO\IPS\Documents\OrderDocument;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly
+        exit; // Exit if accessed directly
 }
 
 if ( ! class_exists( '\\WPO\\IPS\\CustomXmlExporter' ) ) :
 
 class CustomXmlExporter {
-    /**
-     * Singleton instance.
-     *
-     * @var self|null
-     */
-    protected static ?self $instance = null;
 
-    /**
-     * Retrieve singleton instance.
-     */
-    public static function instance(): self {
-        if ( is_null( self::$instance ) ) {
-            self::$instance = new self();
+        /**
+         * Singleton instance.
+         *
+         * @var self|null
+         */
+        protected static ?self $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         */
+        public static function instance(): self {
+                if ( is_null( self::$instance ) ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
         }
 
-        return self::$instance;
-    }
-
-    /**
-     * Register hooks.
-     */
-    public function __construct() {
-        add_action( 'wpo_wcpdf_pdf_created', array( $this, 'maybe_export_invoice_xml' ), 10, 2 );
-        add_filter( 'wpo_wcpdf_listing_actions', array( $this, 'add_invoice_xml_listing_action' ), 10, 2 );
-        add_action( 'wp_ajax_wpo_wcpdf_download_invoice_xml', array( $this, 'handle_invoice_xml_download' ) );
-    }
-
-    /**
-     * Generate XML whenever an invoice PDF is created.
-     *
-     * @param string        $pdf
-     * @param OrderDocument $document
-     */
-    public function maybe_export_invoice_xml( $pdf, $document ): void {
-        if ( ! $document instanceof OrderDocument ) {
-            return;
+        /**
+         * Register hooks.
+         */
+        protected function __construct() {
+                add_filter( 'wpo_wcpdf_document_output_formats', array( $this, 'register_invoice_xml_output_format' ), 20, 2 );
+                add_filter( 'wpo_wcpdf_document_is_enabled', array( $this, 'force_invoice_xml_enabled' ), 10, 3 );
         }
 
-        if ( 'invoice' !== $document->get_type() ) {
-            return;
+        /**
+         * Ensure invoices advertise XML as an available output format.
+         */
+        public function register_invoice_xml_output_format( array $formats, $document ): array {
+                $document_type = is_object( $document ) && is_callable( array( $document, 'get_type' ) ) ? $document->get_type() : '';
+
+                if ( 'invoice' === $document_type && ! in_array( 'xml', $formats, true ) ) {
+                        $formats[] = 'xml';
+                }
+
+                return $formats;
         }
 
-        if ( isset( $_REQUEST['action'] ) && 'wpo_wcpdf_preview' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-            return;
+        /**
+         * Make sure invoice XML output is considered enabled.
+         */
+        public function force_invoice_xml_enabled( $enabled, string $document_type, string $output_format ) {
+                if ( 'invoice' === $document_type && 'xml' === $output_format ) {
+                        return true;
+                }
+
+                return $enabled;
         }
 
-        if ( ! apply_filters( 'wpo_wcpdf_enable_invoice_xml_export', true, $document ) ) {
-            return;
+        /**
+         * Stream XML for a single invoice document.
+         */
+        public function output_document_xml( OrderDocument $document ): void {
+                $xml = $this->get_document_xml_contents( $document );
+
+                if ( '' === $xml ) {
+                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                }
+
+                $filename = $document->get_filename( 'download', array( 'output' => 'xml' ) );
+
+                $this->stream_xml_contents( $xml, $filename );
         }
 
-        $order = $document->order;
+        /**
+         * Stream XML for a bulk invoice document.
+         */
+        public function output_bulk_document_xml( BulkDocument $bulk_document ): void {
+                if ( 'invoice' !== $bulk_document->get_type() ) {
+                        wp_die( esc_html__( 'Invoice XML export is only available for invoices.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                }
 
-        if ( ! $order instanceof WC_Abstract_Order ) {
-            return;
+                $xml = $this->get_bulk_document_xml_contents( $bulk_document );
+
+                if ( '' === $xml ) {
+                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                }
+
+                $filename = $bulk_document->get_filename( 'download', array( 'output' => 'xml' ) );
+
+                $this->stream_xml_contents( $xml, $filename );
         }
 
-        $this->export_invoice_xml( $document, $order );
-    }
+        /**
+         * Generate XML contents for a single document without streaming.
+         */
+        public function get_document_xml_contents( OrderDocument $document ): string {
+                if ( 'invoice' !== $document->get_type() ) {
+                        return '';
+                }
 
-    /**
-     * Add the XML download action to the order listing table.
-     */
-    public function add_invoice_xml_listing_action( array $actions, $order ): array {
-        if ( ! apply_filters( 'wpo_wcpdf_enable_invoice_xml_listing_action', true, $order ) ) {
-            return $actions;
+                $order = $this->resolve_order_from_document( $document );
+
+                if ( ! $order ) {
+                        return '';
+                }
+
+                $data = $this->prepare_invoice_data( $document, $order );
+
+                if ( empty( $data ) ) {
+                        return '';
+                }
+
+                $data = apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
+
+                if ( empty( $data ) ) {
+                        return '';
+                }
+
+                $xml = $this->render_xml_document( array( $data ) );
+
+                return apply_filters( 'wpo_wcpdf_invoice_xml_export_xml', $xml, $data, $document, $order );
         }
 
-        if ( ! $order instanceof WC_Abstract_Order ) {
-            if ( is_numeric( $order ) ) {
-                $order = wc_get_order( absint( $order ) );
-            } else {
-                return $actions;
-            }
+        /**
+         * Generate XML contents for a bulk document without streaming.
+         */
+        public function get_bulk_document_xml_contents( BulkDocument $bulk_document ): string {
+                $order_ids = property_exists( $bulk_document, 'order_ids' ) ? (array) $bulk_document->order_ids : array();
+
+                if ( empty( $order_ids ) ) {
+                        return '';
+                }
+
+                $invoices = array();
+
+                foreach ( $order_ids as $order_id ) {
+                        $order = wc_get_order( $order_id );
+
+                        if ( ! $order instanceof WC_Abstract_Order ) {
+                                continue;
+                        }
+
+                        $document = wcpdf_get_document( $bulk_document->get_type(), $order, true );
+
+                        if ( ! $document instanceof OrderDocument ) {
+                                continue;
+                        }
+
+                        $data = $this->prepare_invoice_data( $document, $order );
+
+                        if ( empty( $data ) ) {
+                                continue;
+                        }
+
+                        $data = apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
+
+                        if ( empty( $data ) ) {
+                                continue;
+                        }
+
+                        $invoices[] = $data;
+                }
+
+                if ( empty( $invoices ) ) {
+                        return '';
+                }
+
+                $xml = $this->render_xml_document( $invoices );
+
+                return apply_filters( 'wpo_wcpdf_invoice_xml_export_bulk_xml', $xml, $invoices, $bulk_document );
         }
 
-        if ( ! $order instanceof WC_Abstract_Order ) {
-            return $actions;
+        /**
+         * Persist XML contents for a document to the provided path.
+         */
+        public function write_document_xml_file( OrderDocument $document, string $path ): bool {
+                $xml = $this->get_document_xml_contents( $document );
+
+                if ( '' === $xml ) {
+                        return false;
+                }
+
+                $xml = $this->normalize_xml_output( $xml );
+
+                if ( '' === $xml ) {
+                        return false;
+                }
+
+                $filesystem = WPO_WCPDF()->file_system;
+
+                $directory = dirname( $path );
+
+                if ( ! $filesystem->is_dir( $directory ) && ! $filesystem->mkdir( $directory ) ) {
+                        return false;
+                }
+
+                return (bool) $filesystem->put_contents( $path, $xml );
         }
 
-        if ( ! WPO_WCPDF()->admin->user_can_manage_document( 'invoice' ) ) {
-            return $actions;
+        /**
+         * Resolve the WooCommerce order attached to the document.
+         */
+        protected function resolve_order_from_document( OrderDocument $document ): ?WC_Abstract_Order {
+                if ( $document->order instanceof WC_Abstract_Order ) {
+                        return $document->order;
+                }
+
+                if ( ! empty( $document->order_id ) ) {
+                        $order = wc_get_order( $document->order_id );
+
+                        if ( $order instanceof WC_Abstract_Order ) {
+                                return $order;
+                        }
+                }
+
+                return null;
         }
 
-        $document = wcpdf_get_document( 'invoice', $order );
+        /**
+         * Stream XML contents to the browser.
+         */
+        protected function stream_xml_contents( string $xml, string $filename ): void {
+                $xml = $this->normalize_xml_output( $xml );
 
-        if ( ! $document ) {
-            return $actions;
+                if ( '' === $xml ) {
+                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                }
+
+                while ( ob_get_level() > 0 ) {
+                        ob_end_clean();
+                }
+
+                header( 'Content-Type: application/xml; charset=utf-8' );
+                header( sprintf( 'Content-Disposition: attachment; filename="%s"', addcslashes( $filename, "\\\"" ) ) );
+                header( 'Content-Length: ' . strlen( $xml ) );
+
+                echo $xml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                exit;
         }
 
-        $exists  = $this->invoice_xml_exists( $document );
-        $classes = array( $document->get_type(), 'xml', 'wpo-wcpdf' );
+        /**
+         * Build the XML document for the provided invoices.
+         */
+        protected function render_xml_document( array $invoices ): string {
+                $dom              = new DOMDocument( '1.0', 'UTF-8' );
+                $dom->formatOutput = true;
 
-        if ( $exists ) {
-            $classes[] = 'exists';
+                $root = $dom->createElement( 'Pohladavky' );
+                $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance' );
+                $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsd', 'http://www.w3.org/2001/XMLSchema' );
+                $dom->appendChild( $root );
+
+                $list_node = $dom->createElement( 'ZoznamPohladavok' );
+                $root->appendChild( $list_node );
+
+                foreach ( $invoices as $invoice ) {
+                        if ( ! is_array( $invoice ) ) {
+                                continue;
+                        }
+
+                        $invoice_node = $this->create_invoice_node( $dom, $invoice );
+
+                        if ( $invoice_node ) {
+                                $list_node->appendChild( $invoice_node );
+                        }
+                }
+
+                if ( 0 === $list_node->childNodes->length ) {
+                        return '';
+                }
+
+                return $dom->saveXML() ?: '';
         }
 
-        $actions['invoice_xml'] = array(
-            'url'           => $this->get_download_url( $document ),
-            'img'           => $this->get_icon_url(),
-            'alt'           => esc_attr__( 'Invoice XML', 'woocommerce-pdf-invoices-packing-slips' ),
-            'exists'        => $exists,
-            'printed'       => false,
-            'class'         => apply_filters( 'wpo_wcpdf_invoice_xml_action_class', implode( ' ', $classes ), $document, $order ),
-            'output_format' => 'xml',
-        );
+        /**
+         * Create a DOM node representing a single invoice.
+         */
+        protected function create_invoice_node( DOMDocument $dom, array $data ) {
+                if ( empty( $data ) ) {
+                        return null;
+                }
 
-        return $actions;
-    }
+                $invoice_node = $dom->createElement( 'Pohladavka' );
 
-    /**
-     * Handle invoice XML downloads triggered from the order actions.
-     */
-    public function handle_invoice_xml_download(): void {
-        if ( ! check_ajax_referer( 'wpo_wcpdf_download_invoice_xml', 'nonce', false ) ) {
-            wp_die( esc_html__( 'Invalid invoice XML request.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                foreach ( $data as $key => $value ) {
+                        if ( 'Partner' === $key && is_array( $value ) ) {
+                                $partner_node = $dom->createElement( 'Partner' );
+
+                                foreach ( $value as $partner_key => $partner_value ) {
+                                        $this->append_node_with_value( $dom, $partner_node, $partner_key, $partner_value );
+                                }
+
+                                if ( $partner_node->hasChildNodes() ) {
+                                        $invoice_node->appendChild( $partner_node );
+                                }
+
+                                continue;
+                        }
+
+                        $this->append_node_with_value( $dom, $invoice_node, $key, $value );
+                }
+
+                return $invoice_node;
         }
 
-        if ( ! WPO_WCPDF()->admin->user_can_manage_document( 'invoice' ) ) {
-            wp_die( esc_html__( 'You do not have permission to download invoice XML files.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        /**
+         * Append a node with value to the parent element.
+         */
+        protected function append_node_with_value( DOMDocument $dom, \DOMElement $parent, string $name, $value ): void {
+                $child = $dom->createElement( $name );
+                $child->appendChild( $dom->createTextNode( (string) $value ) );
+                $parent->appendChild( $child );
         }
 
-        $order_id = isset( $_GET['order_id'] ) ? absint( $_GET['order_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        /**
+         * Prepare data structure used for XML export.
+         */
+        protected function prepare_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
+                $data = $this->collect_invoice_data( $document, $order );
 
-        if ( $order_id <= 0 ) {
-            wp_die( esc_html__( 'Missing order reference for invoice XML download.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                if ( empty( $data ) ) {
+                        return array();
+                }
+
+                return array_map( array( $this, 'stringify_value' ), $data );
         }
 
-        $order = wc_get_order( $order_id );
+        /**
+         * Collect invoice data before type normalization.
+         */
+        protected function collect_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
+                $invoice_number  = $this->resolve_invoice_number( $document );
+                $variable_symbol = $this->resolve_variable_symbol( $invoice_number );
+                $issue_date      = $this->format_date_value( $document->get_date( '', null, 'view', false ), time() );
+                $due_date        = $this->format_due_date( $document, $issue_date );
+                $tax_date        = $this->format_tax_date( $document, $order, $issue_date );
+                $partner_name    = $this->resolve_partner_name( $order );
+                $ico             = $this->get_order_meta_value( $order, array( '_billing_ico', 'billing_ico', '_customer_ico' ) );
+                $dic             = $this->get_order_meta_value( $order, array( '_billing_dic', 'billing_dic', '_customer_dic' ) );
+                $ic_dph          = $this->get_order_meta_value( $order, array( '_billing_ic_dph', 'billing_ic_dph', '_customer_vat', '_billing_vat', '_billing_vat_number', '_billing_tax_id' ) );
 
-        if ( ! $order instanceof WC_Abstract_Order ) {
-            wp_die( esc_html__( 'Unable to find the requested order for invoice XML download.', 'woocommerce-pdf-invoices-packing-slips' ) );
+                if ( '' === $ic_dph && function_exists( 'wpo_wcpdf_get_order_customer_vat_number' ) ) {
+                        $vat_number = wpo_wcpdf_get_order_customer_vat_number( $order );
+
+                        if ( ! empty( $vat_number ) ) {
+                                $ic_dph = $vat_number;
+                        }
+                }
+
+                $ico    = '' !== $ico ? $ico : '0';
+                $dic    = '' !== $dic ? $dic : '0';
+                $ic_dph = '' !== $ic_dph ? $ic_dph : '0';
+
+                $subject = $this->resolve_subject( $document, $order );
+                $total   = wc_format_decimal( $order->get_total(), 2 );
+
+                if ( '' === $total ) {
+                        $total = '0';
+                }
+
+                return array(
+                        'InterneCislo'      => $invoice_number,
+                        'VariabilnySymbol'  => $variable_symbol,
+                        'Partner'           => array(
+                                'NazovPartnera' => $partner_name,
+                                'ICO'           => $ico,
+                                'DIC'           => $dic,
+                                'IC_DPH'        => $ic_dph,
+                        ),
+                        'Vyhotovene'        => $issue_date,
+                        'Splatnost'         => $due_date,
+                        'DVDP'              => $tax_date,
+                        'PredmetFakturacie' => $subject,
+                        'SumaNevstupuje'    => $total,
+                        'KurzPohladavky'    => '1',
+                        'KurzDPH'           => '1',
+                        'MenaDokladu'       => $order->get_currency(),
+                );
         }
 
-        $document = wcpdf_get_document( 'invoice', $order );
+        /**
+         * Convert nested values to strings.
+         */
+        protected function stringify_value( $value ) {
+                if ( is_array( $value ) ) {
+                        foreach ( $value as $key => $child ) {
+                                $value[ $key ] = $this->stringify_value( $child );
+                        }
 
-        if ( ! $document ) {
-            wp_die( esc_html__( 'Unable to load the invoice document for XML export.', 'woocommerce-pdf-invoices-packing-slips' ) );
-        }
+                        return $value;
+                }
 
-        $force_regeneration = isset( $_GET['regenerate'] ) && wc_string_to_bool( wp_unslash( $_GET['regenerate'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                if ( is_bool( $value ) ) {
+                        return $value ? '1' : '0';
+                }
 
-        $path = $this->export_invoice_xml( $document, $order, $force_regeneration );
+                if ( is_scalar( $value ) ) {
+                        return (string) $value;
+                }
 
-        if ( empty( $path ) || ! WPO_WCPDF()->file_system->exists( $path ) ) {
-            $path = $this->get_invoice_xml_path( $document, $order );
-        }
-
-        if ( empty( $path ) || ! WPO_WCPDF()->file_system->exists( $path ) ) {
-            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
-        }
-
-        $this->stream_invoice_xml( $path );
-    }
-
-    /**
-     * Generate and persist the XML file for an invoice document.
-     */
-    protected function export_invoice_xml( OrderDocument $document, WC_Abstract_Order $order, bool $force_regeneration = false ) {
-        $data = $this->prepare_invoice_data( $document, $order );
-
-        if ( empty( $data ) ) {
-            return false;
-        }
-
-        $xml = $this->generate_xml_contents( $data );
-
-        if ( empty( $xml ) ) {
-            return false;
-        }
-
-        $xml = apply_filters( 'wpo_wcpdf_invoice_xml_export_xml', $xml, $data, $document, $order );
-
-        $xml = $this->normalize_xml_output( $xml );
-
-        if ( empty( $xml ) ) {
-            return false;
-        }
-
-        $path = $this->get_invoice_xml_path( $document, $order, $data );
-
-        if ( empty( $path ) ) {
-            return false;
-        }
-
-        if ( ! $force_regeneration && WPO_WCPDF()->file_system->exists( $path ) ) {
-            $existing = WPO_WCPDF()->file_system->get_contents( $path );
-            $cleaned  = $this->normalize_xml_output( $existing );
-
-            if ( ! empty( $cleaned ) && $cleaned !== $existing ) {
-                WPO_WCPDF()->file_system->put_contents( $path, $cleaned );
-            }
-
-            return $path;
-        }
-
-        $directory = dirname( $path );
-
-        if ( ! WPO_WCPDF()->file_system->is_dir( $directory ) ) {
-            if ( ! WPO_WCPDF()->file_system->mkdir( $directory ) ) {
-                wcpdf_log_error( sprintf( 'Unable to create directory for invoice XML export: %s', $directory ), 'error' );
-                return false;
-            }
-        }
-
-        if ( ! WPO_WCPDF()->file_system->put_contents( $path, $xml ) ) {
-            wcpdf_log_error( sprintf( 'Failed to write invoice XML to %s', $path ), 'error' );
-            return false;
-        }
-
-        do_action( 'wpo_wcpdf_invoice_xml_exported', $path, $data, $document, $order );
-
-        return $path;
-    }
-
-    /**
-     * Determine if the invoice XML already exists on disk.
-     */
-    protected function invoice_xml_exists( OrderDocument $document ): bool {
-        $path = $this->get_invoice_xml_path( $document, $document->order instanceof WC_Abstract_Order ? $document->order : null );
-
-        if ( empty( $path ) ) {
-            return false;
-        }
-
-        return WPO_WCPDF()->file_system->exists( $path );
-    }
-
-    /**
-     * Build the download URL used for the admin order action.
-     */
-    protected function get_download_url( OrderDocument $document ): string {
-        $args = array(
-            'action'   => 'wpo_wcpdf_download_invoice_xml',
-            'order_id' => $document->order_id,
-            'nonce'    => wp_create_nonce( 'wpo_wcpdf_download_invoice_xml' ),
-        );
-
-        return apply_filters( 'wpo_wcpdf_invoice_xml_download_url', add_query_arg( $args, admin_url( 'admin-ajax.php' ) ), $document );
-    }
-
-    /**
-     * Retrieve the icon used for the XML action button.
-     */
-    protected function get_icon_url(): string {
-        $icon = WPO_WCPDF()->plugin_url() . '/assets/images/invoice-xml.svg';
-
-        return apply_filters( 'wpo_wcpdf_invoice_xml_action_icon', $icon );
-    }
-
-    /**
-     * Resolve the target path for the XML export.
-     */
-    protected function get_invoice_xml_path( OrderDocument $document, ?WC_Abstract_Order $order = null, array $data = array() ) {
-        $order     = $order instanceof WC_Abstract_Order ? $order : ( $document->order instanceof WC_Abstract_Order ? $document->order : null );
-        $directory = apply_filters( 'wpo_wcpdf_invoice_xml_export_directory', $this->resolve_export_directory(), $document, $order, $data );
-
-        if ( empty( $directory ) ) {
-            return false;
-        }
-
-        $directory = trailingslashit( $directory );
-
-        $filename = $this->resolve_filename( $document );
-        $filename = apply_filters( 'wpo_wcpdf_invoice_xml_export_filename', $filename, $document, $order, $data );
-        $filename = sanitize_file_name( $filename );
-
-        if ( '' === $filename ) {
-            return false;
-        }
-
-        return $directory . $filename;
-    }
-
-    /**
-     * Stream the XML file to the browser.
-     */
-    protected function stream_invoice_xml( string $path ): void {
-        $filename = basename( $path );
-        $contents = WPO_WCPDF()->file_system->get_contents( $path );
-
-        // Teljes buffer takarítás – ez a kulcs
-        while ( ob_get_level() > 0 ) {
-            ob_end_clean();
-        }
-
-        // (opcionális) tömörítés kikapcsolása
-        @ini_set( 'zlib.output_compression', 'Off' );
-
-        // Biztonsági normalizálás a kiküldés ELŐTT
-        $contents = $this->normalize_xml_output( $contents );
-
-        header( 'Content-Type: application/xml; charset=utf-8' );
-        header( sprintf( 'Content-Disposition: attachment; filename="%s"', addcslashes( $filename, "\\\"" ) ) );
-        header( 'Content-Length: ' . strlen( $contents ) );
-
-        echo $contents; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        exit;
-    }
-
-    /**
-     * Prepare invoice data array and apply filters.
-     */
-    protected function prepare_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
-        $data = $this->collect_invoice_data( $document, $order );
-
-        if ( empty( $data ) ) {
-            return array();
-        }
-
-        return apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
-    }
-
-    /**
-     * Ensure XML output starts with a valid declaration and has no leading BOM/whitespace.
-     */
-    protected function normalize_xml_output( $xml ): string {
-        if ( ! is_string( $xml ) ) {
-            return '';
-        }
-
-        if ( 0 === strpos( $xml, "\xEF\xBB\xBF" ) ) {
-            $xml = substr( $xml, 3 );
-        }
-
-        if ( '' === $xml ) {
-            return '';
-        }
-
-        // Remove anything that appears before the first tag to guarantee no blank line precedes the declaration.
-        $first_tag_position = strpos( $xml, '<' );
-
-        if ( false === $first_tag_position ) {
-            return '';
-        }
-
-        if ( $first_tag_position > 0 ) {
-            $xml = substr( $xml, $first_tag_position );
-        }
-
-        if ( '' === $xml ) {
-            return '';
-        }
-
-        // Strip any residual ASCII control characters that might still exist before the first tag.
-        $xml = ltrim( $xml, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20" );
-
-        if ( '' === $xml ) {
-            return '';
-        }
-
-        if ( 0 === strpos( $xml, '<?xml' ) ) {
-            $xml = preg_replace_callback(
-                '/^<\?xml[^>]*\?>\s*/u',
-                static function ( $matches ) {
-                    return rtrim( $matches[0] ) . "\n";
-                },
-                $xml,
-                1
-            );
-
-            if ( ! is_string( $xml ) ) {
                 return '';
-            }
-
-            return $xml;
         }
 
-        return '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . $xml;
-    }
-
-    /**
-     * Build array data used for XML export.
-     */
-    protected function collect_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
-        $invoice_number   = $this->resolve_invoice_number( $document );
-        $variable_symbol  = $this->resolve_variable_symbol( $invoice_number );
-        $issue_date       = $this->format_date_value( $document->get_date( '', null, 'view', false ), time() );
-        $due_date         = $this->format_due_date( $document, $issue_date );
-        $tax_date         = $this->format_tax_date( $document, $order, $issue_date );
-        $partner_name     = $this->resolve_partner_name( $order );
-        $ico              = $this->get_order_meta_value( $order, array( '_billing_ico', 'billing_ico', '_customer_ico' ) );
-        $dic              = $this->get_order_meta_value( $order, array( '_billing_dic', 'billing_dic', '_customer_dic' ) );
-        $ic_dph           = $this->get_order_meta_value( $order, array( '_billing_ic_dph', 'billing_ic_dph', '_customer_vat', '_billing_vat', '_billing_vat_number', '_billing_tax_id' ) );
-
-        if ( '' === $ic_dph && function_exists( 'wpo_wcpdf_get_order_customer_vat_number' ) ) {
-            $vat_number = wpo_wcpdf_get_order_customer_vat_number( $order );
-            if ( ! empty( $vat_number ) ) {
-                $ic_dph = $vat_number;
-            }
-        }
-
-        $ico    = '' !== $ico ? $ico : '0';
-        $dic    = '' !== $dic ? $dic : '0';
-        $ic_dph = '' !== $ic_dph ? $ic_dph : '0';
-
-        $subject = $this->resolve_subject( $document, $order );
-        $total   = wc_format_decimal( $order->get_total(), 2 );
-
-        if ( '' === $total ) {
-            $total = '0';
-        }
-
-        $data = array(
-            'InterneCislo'      => $invoice_number,
-            'VariabilnySymbol'  => $variable_symbol,
-            'Partner'           => array(
-                'NazovPartnera' => $partner_name,
-                'ICO'           => $ico,
-                'DIC'           => $dic,
-                'IC_DPH'        => $ic_dph,
-            ),
-            'Vyhotovene'        => $issue_date,
-            'Splatnost'         => $due_date,
-            'DVDP'              => $tax_date,
-            'PredmetFakturacie' => $subject,
-            'SumaNevstupuje'    => $total,
-            'KurzPohladavky'    => '1',
-            'KurzDPH'           => '1',
-            'MenaDokladu'       => $order->get_currency(),
-        );
-
-        return array_map( array( $this, 'stringify_value' ), $data );
-    }
-
-    /**
-     * Resolve formatted invoice number.
-     */
-    protected function resolve_invoice_number( OrderDocument $document ): string {
-        $invoice_number = $document->get_number( '', null, 'view', true );
-        $invoice_number = is_string( $invoice_number ) ? trim( $invoice_number ) : '';
-
-        if ( '' === $invoice_number ) {
-            $raw_number = $document->get_number();
-            if ( is_object( $raw_number ) && is_callable( array( $raw_number, 'get_formatted' ) ) ) {
-                $invoice_number = trim( (string) $raw_number->get_formatted() );
-            }
-        }
-
-        return $invoice_number;
-    }
-
-    /**
-     * Convert invoice number into a numeric variable symbol.
-     */
-    protected function resolve_variable_symbol( string $invoice_number ): string {
-        $variable_symbol = preg_replace( '/\D+/', '', $invoice_number );
-
-        if ( '' === $variable_symbol ) {
-            $variable_symbol = $invoice_number;
-        }
-
-        return $variable_symbol;
-    }
-
-    /**
-     * Convert values to strings while preserving array structure.
-     */
-    protected function stringify_value( $value ) {
-        if ( is_array( $value ) ) {
-            foreach ( $value as $key => $child ) {
-                $value[ $key ] = $this->stringify_value( $child );
-            }
-
-            return $value;
-        }
-
-        if ( is_bool( $value ) ) {
-            return $value ? '1' : '0';
-        }
-
-        if ( is_scalar( $value ) ) {
-            return (string) $value;
-        }
-
-        return '';
-    }
-
-    /**
-     * Create XML string from data.
-     */
-    protected function generate_xml_contents( array $data ): string {
-        $dom              = new DOMDocument( '1.0', 'UTF-8' );
-        $dom->formatOutput = true;
-
-        $root = $dom->createElement( 'Pohladavky' );
-        $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance' );
-        $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsd', 'http://www.w3.org/2001/XMLSchema' );
-        $dom->appendChild( $root );
-
-        $list_node    = $dom->createElement( 'ZoznamPohladavok' );
-        $invoice_node = $dom->createElement( 'Pohladavka' );
-
-        foreach ( $data as $key => $value ) {
-            if ( 'Partner' === $key && is_array( $value ) ) {
-                $partner_node = $dom->createElement( 'Partner' );
-                foreach ( $value as $partner_key => $partner_value ) {
-                    $this->append_node_with_value( $dom, $partner_node, $partner_key, $partner_value );
+        /**
+         * Ensure XML starts with a declaration and is free of leading BOM/whitespace.
+         */
+        protected function normalize_xml_output( $xml ): string {
+                if ( ! is_string( $xml ) ) {
+                        return '';
                 }
-                $invoice_node->appendChild( $partner_node );
-                continue;
-            }
 
-            $this->append_node_with_value( $dom, $invoice_node, $key, $value );
-        }
-
-        $list_node->appendChild( $invoice_node );
-        $root->appendChild( $list_node );
-
-        return $dom->saveXML() ?: '';
-    }
-
-    /**
-     * Append a text node to the given DOM element.
-     */
-    protected function append_node_with_value( DOMDocument $dom, \DOMElement $parent, string $name, $value ): void {
-        $child = $dom->createElement( $name );
-        $child->appendChild( $dom->createTextNode( (string) $value ) );
-        $parent->appendChild( $child );
-    }
-
-    /**
-     * Determine where to store the exported XML file.
-     */
-    protected function resolve_export_directory() {
-        $path = WPO_WCPDF()->main->get_tmp_path( 'attachments' );
-
-        if ( $path ) {
-            return $path;
-        }
-
-        $uploads = wp_upload_dir();
-
-        return isset( $uploads['basedir'] ) ? $uploads['basedir'] : false;
-    }
-
-    /**
-     * Create filename for the exported XML.
-     */
-    protected function resolve_filename( OrderDocument $document ): string {
-        $base = $document->get_filename( 'download', array( 'output' => 'ubl' ) );
-        $base = preg_replace( '/\.xml$/i', '', $base );
-
-        if ( empty( $base ) ) {
-            $base = 'invoice-' . $document->order_id;
-        }
-
-        return $base . '.xml';
-    }
-
-    /**
-     * Format invoice date values as YYYY-MM-DD.
-     */
-    protected function format_date_value( $value, int $fallback_timestamp ): string {
-        if ( $value instanceof \WC_DateTime ) {
-            return $value->date( 'Y-m-d' );
-        }
-
-        if ( $value instanceof \DateTimeInterface ) {
-            return $value->format( 'Y-m-d' );
-        }
-
-        if ( is_numeric( $value ) ) {
-            return wp_date( 'Y-m-d', (int) $value );
-        }
-
-        if ( is_string( $value ) && '' !== $value ) {
-            $timestamp = strtotime( $value );
-            if ( false !== $timestamp ) {
-                return wp_date( 'Y-m-d', $timestamp );
-            }
-        }
-
-        return wp_date( 'Y-m-d', $fallback_timestamp );
-    }
-
-    /**
-     * Format due date using document configuration.
-     */
-    protected function format_due_date( OrderDocument $document, string $fallback ): string {
-        $timestamp = $document->get_due_date();
-
-        if ( $timestamp > 0 ) {
-            return wp_date( 'Y-m-d', $timestamp );
-        }
-
-        return $fallback;
-    }
-
-    /**
-     * Determine tax date (DVDP) based on document settings.
-     */
-    protected function format_tax_date( OrderDocument $document, WC_Abstract_Order $order, string $fallback ): string {
-        $display_date_setting = $document->get_display_date();
-
-        if ( 'order_date' === $display_date_setting ) {
-            $order_date = $order->get_date_created();
-            if ( $order_date instanceof \WC_DateTime ) {
-                return $order_date->date( 'Y-m-d' );
-            }
-            if ( $order_date instanceof \DateTimeInterface ) {
-                return $order_date->format( 'Y-m-d' );
-            }
-        }
-
-        return $fallback;
-    }
-
-    /**
-     * Attempt to find company name or fallback to customer name.
-     */
-    protected function resolve_partner_name( WC_Abstract_Order $order ): string {
-        $partner_name = $order->get_billing_company();
-
-        if ( empty( $partner_name ) ) {
-            $partner_name = trim( $order->get_formatted_billing_full_name() );
-        }
-
-        if ( empty( $partner_name ) ) {
-            $partner_name = trim( $order->get_formatted_shipping_full_name() );
-        }
-
-        if ( empty( $partner_name ) ) {
-            $partner_name = __( 'Customer', 'woocommerce-pdf-invoices-packing-slips' );
-        }
-
-        return wc_clean( $partner_name );
-    }
-
-    /**
-     * Fetch the first non-empty meta value from the provided keys.
-     */
-    protected function get_order_meta_value( WC_Abstract_Order $order, array $keys ): string {
-        foreach ( $keys as $key ) {
-            $value = $order->get_meta( $key );
-            if ( ! empty( $value ) ) {
-                return wc_clean( (string) $value );
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Build invoice subject using purchased items.
-     */
-    protected function resolve_subject( OrderDocument $document, WC_Abstract_Order $order ): string {
-        $items = $document->get_order_items();
-        $names = array();
-
-        if ( ! empty( $items ) && is_array( $items ) ) {
-            foreach ( $items as $item ) {
-                if ( isset( $item['name'] ) && '' !== $item['name'] ) {
-                    $names[] = wc_clean( wp_strip_all_tags( (string) $item['name'] ) );
+                if ( 0 === strpos( $xml, "\xEF\xBB\xBF" ) ) {
+                        $xml = substr( $xml, 3 );
                 }
-            }
+
+                if ( '' === $xml ) {
+                        return '';
+                }
+
+                $first_tag_position = strpos( $xml, '<' );
+
+                if ( false === $first_tag_position ) {
+                        return '';
+                }
+
+                if ( $first_tag_position > 0 ) {
+                        $xml = substr( $xml, $first_tag_position );
+                }
+
+                if ( '' === $xml ) {
+                        return '';
+                }
+
+                $xml = ltrim( $xml, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20" );
+
+                if ( '' === $xml ) {
+                        return '';
+                }
+
+                if ( 0 === strpos( $xml, '<?xml' ) ) {
+                        $xml = preg_replace_callback(
+                                '/^<\?xml[^>]*\?>\s*/u',
+                                static function ( $matches ) {
+                                        return rtrim( $matches[0] ) . "\n";
+                                },
+                                $xml,
+                                1
+                        );
+
+                        if ( ! is_string( $xml ) ) {
+                                return '';
+                        }
+
+                        return $xml;
+                }
+
+                return '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . $xml;
         }
 
-        $names = array_filter( array_unique( $names ) );
+        /**
+         * Resolve formatted invoice number.
+         */
+        protected function resolve_invoice_number( OrderDocument $document ): string {
+                $invoice_number = $document->get_number( '', null, 'view', true );
+                $invoice_number = is_string( $invoice_number ) ? trim( $invoice_number ) : '';
 
-        if ( ! empty( $names ) ) {
-            return implode( ', ', $names );
+                if ( '' === $invoice_number ) {
+                        $raw_number = $document->get_number();
+                        if ( is_object( $raw_number ) && is_callable( array( $raw_number, 'get_formatted' ) ) ) {
+                                $invoice_number = trim( (string) $raw_number->get_formatted() );
+                        }
+                }
+
+                return $invoice_number;
         }
 
-        return sprintf(
-            /* translators: %s: order number */
-            __( 'Order %s', 'woocommerce-pdf-invoices-packing-slips' ),
-            $order->get_order_number()
-        );
-    }
+        /**
+         * Convert invoice number into a numeric variable symbol.
+         */
+        protected function resolve_variable_symbol( string $invoice_number ): string {
+                $variable_symbol = preg_replace( '/\D+/', '', $invoice_number );
+
+                if ( '' === $variable_symbol ) {
+                        $variable_symbol = $invoice_number;
+                }
+
+                return $variable_symbol;
+        }
+
+        /**
+         * Format date values as YYYY-MM-DD.
+         */
+        protected function format_date_value( $value, int $fallback_timestamp ): string {
+                if ( $value instanceof \WC_DateTime ) {
+                        return $value->date( 'Y-m-d' );
+                }
+
+                if ( $value instanceof \DateTimeInterface ) {
+                        return $value->format( 'Y-m-d' );
+                }
+
+                if ( is_numeric( $value ) ) {
+                        return wp_date( 'Y-m-d', (int) $value );
+                }
+
+                if ( is_string( $value ) && '' !== $value ) {
+                        $timestamp = strtotime( $value );
+                        if ( false !== $timestamp ) {
+                                return wp_date( 'Y-m-d', $timestamp );
+                        }
+                }
+
+                return wp_date( 'Y-m-d', $fallback_timestamp );
+        }
+
+        /**
+         * Format due date using document configuration.
+         */
+        protected function format_due_date( OrderDocument $document, string $fallback ): string {
+                $timestamp = $document->get_due_date();
+
+                if ( $timestamp > 0 ) {
+                        return wp_date( 'Y-m-d', $timestamp );
+                }
+
+                return $fallback;
+        }
+
+        /**
+         * Determine tax date based on document settings.
+         */
+        protected function format_tax_date( OrderDocument $document, WC_Abstract_Order $order, string $fallback ): string {
+                $display_date_setting = $document->get_display_date();
+
+                if ( 'order_date' === $display_date_setting ) {
+                        $order_date = $order->get_date_created();
+                        if ( $order_date instanceof \WC_DateTime ) {
+                                return $order_date->date( 'Y-m-d' );
+                        }
+                        if ( $order_date instanceof \DateTimeInterface ) {
+                                return $order_date->format( 'Y-m-d' );
+                        }
+                }
+
+                return $fallback;
+        }
+
+        /**
+         * Determine the partner name from the order data.
+         */
+        protected function resolve_partner_name( WC_Abstract_Order $order ): string {
+                $partner_name = $order->get_billing_company();
+
+                if ( empty( $partner_name ) ) {
+                        $partner_name = trim( $order->get_formatted_billing_full_name() );
+                }
+
+                if ( empty( $partner_name ) ) {
+                        $partner_name = trim( $order->get_formatted_shipping_full_name() );
+                }
+
+                if ( empty( $partner_name ) ) {
+                        $partner_name = __( 'Customer', 'woocommerce-pdf-invoices-packing-slips' );
+                }
+
+                return wc_clean( $partner_name );
+        }
+
+        /**
+         * Fetch the first non-empty meta value from the provided keys.
+         */
+        protected function get_order_meta_value( WC_Abstract_Order $order, array $keys ): string {
+                foreach ( $keys as $key ) {
+                        $value = $order->get_meta( $key );
+                        if ( ! empty( $value ) ) {
+                                return wc_clean( (string) $value );
+                        }
+                }
+
+                return '';
+        }
+
+        /**
+         * Build the invoice subject using purchased items.
+         */
+        protected function resolve_subject( OrderDocument $document, WC_Abstract_Order $order ): string {
+                $items = $document->get_order_items();
+                $names = array();
+
+                if ( ! empty( $items ) && is_array( $items ) ) {
+                        foreach ( $items as $item ) {
+                                if ( isset( $item['name'] ) && '' !== $item['name'] ) {
+                                        $names[] = wc_clean( wp_strip_all_tags( (string) $item['name'] ) );
+                                }
+                        }
+                }
+
+                $names = array_filter( array_unique( $names ) );
+
+                if ( ! empty( $names ) ) {
+                        return implode( ', ', $names );
+                }
+
+                return sprintf(
+                        /* translators: %s: order number */
+                        __( 'Order %s', 'woocommerce-pdf-invoices-packing-slips' ),
+                        $order->get_order_number()
+                );
+        }
 }
 
 endif;

--- a/includes/CustomXmlExporter.php
+++ b/includes/CustomXmlExporter.php
@@ -2,619 +2,918 @@
 namespace WPO\IPS;
 
 use DOMDocument;
-use WC_Abstract_Order;
 use WPO\IPS\Documents\BulkDocument;
 use WPO\IPS\Documents\OrderDocument;
+use WC_Abstract_Order;
 
 if ( ! defined( 'ABSPATH' ) ) {
-        exit; // Exit if accessed directly
+    exit; // Exit if accessed directly
 }
 
 if ( ! class_exists( '\\WPO\\IPS\\CustomXmlExporter' ) ) :
 
 class CustomXmlExporter {
+    /**
+     * Singleton instance.
+     *
+     * @var self|null
+     */
+    protected static ?self $instance = null;
 
-        /**
-         * Singleton instance.
-         *
-         * @var self|null
-         */
-        protected static ?self $instance = null;
-
-        /**
-         * Retrieve singleton instance.
-         */
-        public static function instance(): self {
-                if ( is_null( self::$instance ) ) {
-                        self::$instance = new self();
-                }
-
-                return self::$instance;
+    /**
+     * Retrieve singleton instance.
+     */
+    public static function instance(): self {
+        if ( is_null( self::$instance ) ) {
+            self::$instance = new self();
         }
 
-        /**
-         * Register hooks.
-         */
-        protected function __construct() {
-                add_filter( 'wpo_wcpdf_document_output_formats', array( $this, 'register_invoice_xml_output_format' ), 20, 2 );
-                add_filter( 'wpo_wcpdf_document_is_enabled', array( $this, 'force_invoice_xml_enabled' ), 10, 3 );
+        return self::$instance;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function __construct() {
+        add_action( 'wpo_wcpdf_pdf_created', array( $this, 'maybe_export_invoice_xml' ), 10, 2 );
+        add_filter( 'wpo_wcpdf_listing_actions', array( $this, 'add_invoice_xml_listing_action' ), 10, 2 );
+        add_action( 'wp_ajax_wpo_wcpdf_download_invoice_xml', array( $this, 'handle_invoice_xml_download' ) );
+        add_filter( 'wpo_wcpdf_document_output_formats', array( $this, 'register_invoice_xml_output_format' ), 20, 2 );
+        add_filter( 'wpo_wcpdf_document_is_enabled', array( $this, 'force_invoice_xml_enabled' ), 10, 3 );
+    }
+
+    /**
+     * Ensure invoices advertise XML as an available output format.
+     */
+    public function register_invoice_xml_output_format( array $formats, $document ): array {
+        $document_type = is_object( $document ) && is_callable( array( $document, 'get_type' ) ) ? $document->get_type() : '';
+
+        if ( 'invoice' === $document_type && ! in_array( 'xml', $formats, true ) ) {
+            $formats[] = 'xml';
         }
 
-        /**
-         * Ensure invoices advertise XML as an available output format.
-         */
-        public function register_invoice_xml_output_format( array $formats, $document ): array {
-                $document_type = is_object( $document ) && is_callable( array( $document, 'get_type' ) ) ? $document->get_type() : '';
+        return $formats;
+    }
 
-                if ( 'invoice' === $document_type && ! in_array( 'xml', $formats, true ) ) {
-                        $formats[] = 'xml';
-                }
-
-                return $formats;
+    /**
+     * Make sure invoice XML output is considered enabled.
+     */
+    public function force_invoice_xml_enabled( $enabled, string $document_type, string $output_format ) {
+        if ( 'invoice' === $document_type && 'xml' === $output_format ) {
+            return true;
         }
 
-        /**
-         * Make sure invoice XML output is considered enabled.
-         */
-        public function force_invoice_xml_enabled( $enabled, string $document_type, string $output_format ) {
-                if ( 'invoice' === $document_type && 'xml' === $output_format ) {
-                        return true;
-                }
+        return $enabled;
+    }
 
-                return $enabled;
+    /**
+     * Stream XML for a single invoice document.
+     */
+    public function output_document_xml( OrderDocument $document ): void {
+        $xml = $this->get_document_xml_contents( $document );
+
+        if ( '' === $xml ) {
+            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
         }
 
-        /**
-         * Stream XML for a single invoice document.
-         */
-        public function output_document_xml( OrderDocument $document ): void {
-                $xml = $this->get_document_xml_contents( $document );
+        $filename = $document->get_filename( 'download', array( 'output' => 'xml' ) );
 
-                if ( '' === $xml ) {
-                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
-                }
+        $this->stream_xml_contents( $xml, $filename );
+    }
 
-                $filename = $document->get_filename( 'download', array( 'output' => 'xml' ) );
-
-                $this->stream_xml_contents( $xml, $filename );
+    /**
+     * Stream XML for a bulk invoice document.
+     */
+    public function output_bulk_document_xml( BulkDocument $bulk_document ): void {
+        if ( 'invoice' !== $bulk_document->get_type() ) {
+            wp_die( esc_html__( 'Invoice XML export is only available for invoices.', 'woocommerce-pdf-invoices-packing-slips' ) );
         }
 
-        /**
-         * Stream XML for a bulk invoice document.
-         */
-        public function output_bulk_document_xml( BulkDocument $bulk_document ): void {
-                if ( 'invoice' !== $bulk_document->get_type() ) {
-                        wp_die( esc_html__( 'Invoice XML export is only available for invoices.', 'woocommerce-pdf-invoices-packing-slips' ) );
-                }
+        $xml = $this->get_bulk_document_xml_contents( $bulk_document );
 
-                $xml = $this->get_bulk_document_xml_contents( $bulk_document );
-
-                if ( '' === $xml ) {
-                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
-                }
-
-                $filename = $bulk_document->get_filename( 'download', array( 'output' => 'xml' ) );
-
-                $this->stream_xml_contents( $xml, $filename );
+        if ( '' === $xml ) {
+            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
         }
 
-        /**
-         * Generate XML contents for a single document without streaming.
-         */
-        public function get_document_xml_contents( OrderDocument $document ): string {
-                if ( 'invoice' !== $document->get_type() ) {
-                        return '';
-                }
+        $filename = $bulk_document->get_filename( 'download', array( 'output' => 'xml' ) );
 
-                $order = $this->resolve_order_from_document( $document );
+        $this->stream_xml_contents( $xml, $filename );
+    }
 
-                if ( ! $order ) {
-                        return '';
-                }
-
-                $data = $this->prepare_invoice_data( $document, $order );
-
-                if ( empty( $data ) ) {
-                        return '';
-                }
-
-                $data = apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
-
-                if ( empty( $data ) ) {
-                        return '';
-                }
-
-                $xml = $this->render_xml_document( array( $data ) );
-
-                return apply_filters( 'wpo_wcpdf_invoice_xml_export_xml', $xml, $data, $document, $order );
+    /**
+     * Generate XML contents for a single document without streaming.
+     */
+    public function get_document_xml_contents( OrderDocument $document ): string {
+        if ( 'invoice' !== $document->get_type() ) {
+            return '';
         }
 
-        /**
-         * Generate XML contents for a bulk document without streaming.
-         */
-        public function get_bulk_document_xml_contents( BulkDocument $bulk_document ): string {
-                $order_ids = property_exists( $bulk_document, 'order_ids' ) ? (array) $bulk_document->order_ids : array();
+        $order = $this->resolve_order_from_document( $document );
 
-                if ( empty( $order_ids ) ) {
-                        return '';
-                }
-
-                $invoices = array();
-
-                foreach ( $order_ids as $order_id ) {
-                        $order = wc_get_order( $order_id );
-
-                        if ( ! $order instanceof WC_Abstract_Order ) {
-                                continue;
-                        }
-
-                        $document = wcpdf_get_document( $bulk_document->get_type(), $order, true );
-
-                        if ( ! $document instanceof OrderDocument ) {
-                                continue;
-                        }
-
-                        $data = $this->prepare_invoice_data( $document, $order );
-
-                        if ( empty( $data ) ) {
-                                continue;
-                        }
-
-                        $data = apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
-
-                        if ( empty( $data ) ) {
-                                continue;
-                        }
-
-                        $invoices[] = $data;
-                }
-
-                if ( empty( $invoices ) ) {
-                        return '';
-                }
-
-                $xml = $this->render_xml_document( $invoices );
-
-                return apply_filters( 'wpo_wcpdf_invoice_xml_export_bulk_xml', $xml, $invoices, $bulk_document );
+        if ( ! $order ) {
+            return '';
         }
 
-        /**
-         * Persist XML contents for a document to the provided path.
-         */
-        public function write_document_xml_file( OrderDocument $document, string $path ): bool {
-                $xml = $this->get_document_xml_contents( $document );
+        $data = $this->prepare_invoice_data( $document, $order );
 
-                if ( '' === $xml ) {
-                        return false;
-                }
-
-                $xml = $this->normalize_xml_output( $xml );
-
-                if ( '' === $xml ) {
-                        return false;
-                }
-
-                $filesystem = WPO_WCPDF()->file_system;
-
-                $directory = dirname( $path );
-
-                if ( ! $filesystem->is_dir( $directory ) && ! $filesystem->mkdir( $directory ) ) {
-                        return false;
-                }
-
-                return (bool) $filesystem->put_contents( $path, $xml );
+        if ( empty( $data ) ) {
+            return '';
         }
 
-        /**
-         * Resolve the WooCommerce order attached to the document.
-         */
-        protected function resolve_order_from_document( OrderDocument $document ): ?WC_Abstract_Order {
-                if ( $document->order instanceof WC_Abstract_Order ) {
-                        return $document->order;
-                }
+        $xml = $this->render_xml_document( array( $data ) );
 
-                if ( ! empty( $document->order_id ) ) {
-                        $order = wc_get_order( $document->order_id );
-
-                        if ( $order instanceof WC_Abstract_Order ) {
-                                return $order;
-                        }
-                }
-
-                return null;
+        if ( '' === $xml ) {
+            return '';
         }
 
-        /**
-         * Stream XML contents to the browser.
-         */
-        protected function stream_xml_contents( string $xml, string $filename ): void {
-                $xml = $this->normalize_xml_output( $xml );
+        return apply_filters( 'wpo_wcpdf_invoice_xml_export_xml', $xml, $data, $document, $order );
+    }
 
-                if ( '' === $xml ) {
-                        wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
-                }
+    /**
+     * Generate XML contents for a bulk document without streaming.
+     */
+    public function get_bulk_document_xml_contents( BulkDocument $bulk_document ): string {
+        $order_ids = property_exists( $bulk_document, 'order_ids' ) ? (array) $bulk_document->order_ids : array();
 
-                while ( ob_get_level() > 0 ) {
-                        ob_end_clean();
-                }
-
-                header( 'Content-Type: application/xml; charset=utf-8' );
-                header( sprintf( 'Content-Disposition: attachment; filename="%s"', addcslashes( $filename, "\\\"" ) ) );
-                header( 'Content-Length: ' . strlen( $xml ) );
-
-                echo $xml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                exit;
+        if ( empty( $order_ids ) ) {
+            return '';
         }
 
-        /**
-         * Build the XML document for the provided invoices.
-         */
-        protected function render_xml_document( array $invoices ): string {
-                $dom              = new DOMDocument( '1.0', 'UTF-8' );
-                $dom->formatOutput = true;
+        $invoices = array();
 
-                $root = $dom->createElement( 'Pohladavky' );
-                $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance' );
-                $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsd', 'http://www.w3.org/2001/XMLSchema' );
-                $dom->appendChild( $root );
+        foreach ( $order_ids as $order_id ) {
+            $order = wc_get_order( $order_id );
 
-                $list_node = $dom->createElement( 'ZoznamPohladavok' );
-                $root->appendChild( $list_node );
+            if ( ! $order instanceof WC_Abstract_Order ) {
+                continue;
+            }
 
-                foreach ( $invoices as $invoice ) {
-                        if ( ! is_array( $invoice ) ) {
-                                continue;
-                        }
+            $document = wcpdf_get_document( $bulk_document->get_type(), $order, true );
 
-                        $invoice_node = $this->create_invoice_node( $dom, $invoice );
+            if ( ! $document instanceof OrderDocument ) {
+                continue;
+            }
 
-                        if ( $invoice_node ) {
-                                $list_node->appendChild( $invoice_node );
-                        }
-                }
+            if ( 'invoice' !== $document->get_type() ) {
+                continue;
+            }
 
-                if ( 0 === $list_node->childNodes->length ) {
-                        return '';
-                }
+            $data = $this->prepare_invoice_data( $document, $order );
 
-                return $dom->saveXML() ?: '';
+            if ( empty( $data ) ) {
+                continue;
+            }
+
+            $invoices[] = $data;
         }
 
-        /**
-         * Create a DOM node representing a single invoice.
-         */
-        protected function create_invoice_node( DOMDocument $dom, array $data ) {
-                if ( empty( $data ) ) {
-                        return null;
-                }
-
-                $invoice_node = $dom->createElement( 'Pohladavka' );
-
-                foreach ( $data as $key => $value ) {
-                        if ( 'Partner' === $key && is_array( $value ) ) {
-                                $partner_node = $dom->createElement( 'Partner' );
-
-                                foreach ( $value as $partner_key => $partner_value ) {
-                                        $this->append_node_with_value( $dom, $partner_node, $partner_key, $partner_value );
-                                }
-
-                                if ( $partner_node->hasChildNodes() ) {
-                                        $invoice_node->appendChild( $partner_node );
-                                }
-
-                                continue;
-                        }
-
-                        $this->append_node_with_value( $dom, $invoice_node, $key, $value );
-                }
-
-                return $invoice_node;
+        if ( empty( $invoices ) ) {
+            return '';
         }
 
-        /**
-         * Append a node with value to the parent element.
-         */
-        protected function append_node_with_value( DOMDocument $dom, \DOMElement $parent, string $name, $value ): void {
-                $child = $dom->createElement( $name );
-                $child->appendChild( $dom->createTextNode( (string) $value ) );
-                $parent->appendChild( $child );
+        $xml = $this->render_xml_document( $invoices );
+
+        return apply_filters( 'wpo_wcpdf_invoice_xml_export_bulk_xml', $xml, $invoices, $bulk_document );
+    }
+
+    /**
+     * Persist XML contents for a document to the provided path.
+     */
+    public function write_document_xml_file( OrderDocument $document, string $path ): bool {
+        $xml = $this->get_document_xml_contents( $document );
+
+        if ( '' === $xml ) {
+            return false;
         }
 
-        /**
-         * Prepare data structure used for XML export.
-         */
-        protected function prepare_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
-                $data = $this->collect_invoice_data( $document, $order );
+        $xml = $this->normalize_xml_output( $xml );
 
-                if ( empty( $data ) ) {
-                        return array();
-                }
-
-                return array_map( array( $this, 'stringify_value' ), $data );
+        if ( '' === $xml ) {
+            return false;
         }
 
-        /**
-         * Collect invoice data before type normalization.
-         */
-        protected function collect_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
-                $invoice_number  = $this->resolve_invoice_number( $document );
-                $variable_symbol = $this->resolve_variable_symbol( $invoice_number );
-                $issue_date      = $this->format_date_value( $document->get_date( '', null, 'view', false ), time() );
-                $due_date        = $this->format_due_date( $document, $issue_date );
-                $tax_date        = $this->format_tax_date( $document, $order, $issue_date );
-                $partner_name    = $this->resolve_partner_name( $order );
-                $ico             = $this->get_order_meta_value( $order, array( '_billing_ico', 'billing_ico', '_customer_ico' ) );
-                $dic             = $this->get_order_meta_value( $order, array( '_billing_dic', 'billing_dic', '_customer_dic' ) );
-                $ic_dph          = $this->get_order_meta_value( $order, array( '_billing_ic_dph', 'billing_ic_dph', '_customer_vat', '_billing_vat', '_billing_vat_number', '_billing_tax_id' ) );
+        $filesystem = WPO_WCPDF()->file_system;
 
-                if ( '' === $ic_dph && function_exists( 'wpo_wcpdf_get_order_customer_vat_number' ) ) {
-                        $vat_number = wpo_wcpdf_get_order_customer_vat_number( $order );
+        $directory = dirname( $path );
 
-                        if ( ! empty( $vat_number ) ) {
-                                $ic_dph = $vat_number;
-                        }
-                }
-
-                $ico    = '' !== $ico ? $ico : '0';
-                $dic    = '' !== $dic ? $dic : '0';
-                $ic_dph = '' !== $ic_dph ? $ic_dph : '0';
-
-                $subject = $this->resolve_subject( $document, $order );
-                $total   = wc_format_decimal( $order->get_total(), 2 );
-
-                if ( '' === $total ) {
-                        $total = '0';
-                }
-
-                return array(
-                        'InterneCislo'      => $invoice_number,
-                        'VariabilnySymbol'  => $variable_symbol,
-                        'Partner'           => array(
-                                'NazovPartnera' => $partner_name,
-                                'ICO'           => $ico,
-                                'DIC'           => $dic,
-                                'IC_DPH'        => $ic_dph,
-                        ),
-                        'Vyhotovene'        => $issue_date,
-                        'Splatnost'         => $due_date,
-                        'DVDP'              => $tax_date,
-                        'PredmetFakturacie' => $subject,
-                        'SumaNevstupuje'    => $total,
-                        'KurzPohladavky'    => '1',
-                        'KurzDPH'           => '1',
-                        'MenaDokladu'       => $order->get_currency(),
-                );
+        if ( ! $filesystem->is_dir( $directory ) && ! $filesystem->mkdir( $directory ) ) {
+            return false;
         }
 
-        /**
-         * Convert nested values to strings.
-         */
-        protected function stringify_value( $value ) {
-                if ( is_array( $value ) ) {
-                        foreach ( $value as $key => $child ) {
-                                $value[ $key ] = $this->stringify_value( $child );
-                        }
+        return (bool) $filesystem->put_contents( $path, $xml );
+    }
 
-                        return $value;
-                }
+    /**
+     * Generate XML whenever an invoice PDF is created.
+     *
+     * @param string        $pdf
+     * @param OrderDocument $document
+     */
+    public function maybe_export_invoice_xml( $pdf, $document ): void {
+        if ( ! $document instanceof OrderDocument ) {
+            return;
+        }
 
-                if ( is_bool( $value ) ) {
-                        return $value ? '1' : '0';
-                }
+        if ( 'invoice' !== $document->get_type() ) {
+            return;
+        }
 
-                if ( is_scalar( $value ) ) {
-                        return (string) $value;
-                }
+        if ( isset( $_REQUEST['action'] ) && 'wpo_wcpdf_preview' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return;
+        }
 
+        if ( ! apply_filters( 'wpo_wcpdf_enable_invoice_xml_export', true, $document ) ) {
+            return;
+        }
+
+        $order = $document->order;
+
+        if ( ! $order instanceof WC_Abstract_Order ) {
+            return;
+        }
+
+        $this->export_invoice_xml( $document, $order );
+    }
+
+    /**
+     * Add the XML download action to the order listing table.
+     */
+    public function add_invoice_xml_listing_action( array $actions, $order ): array {
+        if ( ! apply_filters( 'wpo_wcpdf_enable_invoice_xml_listing_action', true, $order ) ) {
+            return $actions;
+        }
+
+        if ( ! $order instanceof WC_Abstract_Order ) {
+            if ( is_numeric( $order ) ) {
+                $order = wc_get_order( absint( $order ) );
+            } else {
+                return $actions;
+            }
+        }
+
+        if ( ! $order instanceof WC_Abstract_Order ) {
+            return $actions;
+        }
+
+        if ( ! WPO_WCPDF()->admin->user_can_manage_document( 'invoice' ) ) {
+            return $actions;
+        }
+
+        $document = wcpdf_get_document( 'invoice', $order );
+
+        if ( ! $document ) {
+            return $actions;
+        }
+
+        $exists  = $this->invoice_xml_exists( $document );
+        $classes = array( $document->get_type(), 'xml', 'wpo-wcpdf' );
+
+        if ( $exists ) {
+            $classes[] = 'exists';
+        }
+
+        $actions['invoice_xml'] = array(
+            'url'           => $this->get_download_url( $document ),
+            'img'           => $this->get_icon_url(),
+            'alt'           => esc_attr__( 'Invoice XML', 'woocommerce-pdf-invoices-packing-slips' ),
+            'exists'        => $exists,
+            'printed'       => false,
+            'class'         => apply_filters( 'wpo_wcpdf_invoice_xml_action_class', implode( ' ', $classes ), $document, $order ),
+            'output_format' => 'xml',
+        );
+
+        return $actions;
+    }
+
+    /**
+     * Handle invoice XML downloads triggered from the order actions.
+     */
+    public function handle_invoice_xml_download(): void {
+        if ( ! check_ajax_referer( 'wpo_wcpdf_download_invoice_xml', 'nonce', false ) ) {
+            wp_die( esc_html__( 'Invalid invoice XML request.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        if ( ! WPO_WCPDF()->admin->user_can_manage_document( 'invoice' ) ) {
+            wp_die( esc_html__( 'You do not have permission to download invoice XML files.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $order_id = isset( $_GET['order_id'] ) ? absint( $_GET['order_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        if ( $order_id <= 0 ) {
+            wp_die( esc_html__( 'Missing order reference for invoice XML download.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $order = wc_get_order( $order_id );
+
+        if ( ! $order instanceof WC_Abstract_Order ) {
+            wp_die( esc_html__( 'Unable to find the requested order for invoice XML download.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $document = wcpdf_get_document( 'invoice', $order );
+
+        if ( ! $document ) {
+            wp_die( esc_html__( 'Unable to load the invoice document for XML export.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $force_regeneration = isset( $_GET['regenerate'] ) && wc_string_to_bool( wp_unslash( $_GET['regenerate'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        $path = $this->export_invoice_xml( $document, $order, $force_regeneration );
+
+        if ( empty( $path ) || ! WPO_WCPDF()->file_system->exists( $path ) ) {
+            $path = $this->get_invoice_xml_path( $document, $order );
+        }
+
+        if ( empty( $path ) || ! WPO_WCPDF()->file_system->exists( $path ) ) {
+            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $this->stream_invoice_xml( $path );
+    }
+
+    /**
+     * Generate and persist the XML file for an invoice document.
+     */
+    protected function export_invoice_xml( OrderDocument $document, WC_Abstract_Order $order, bool $force_regeneration = false ) {
+        $data = $this->prepare_invoice_data( $document, $order );
+
+        if ( empty( $data ) ) {
+            return false;
+        }
+
+        $xml = $this->generate_xml_contents( $data );
+
+        if ( empty( $xml ) ) {
+            return false;
+        }
+
+        $xml = apply_filters( 'wpo_wcpdf_invoice_xml_export_xml', $xml, $data, $document, $order );
+
+        $xml = $this->normalize_xml_output( $xml );
+
+        if ( empty( $xml ) ) {
+            return false;
+        }
+
+        $path = $this->get_invoice_xml_path( $document, $order, $data );
+
+        if ( empty( $path ) ) {
+            return false;
+        }
+
+        if ( ! $force_regeneration && WPO_WCPDF()->file_system->exists( $path ) ) {
+            $existing = WPO_WCPDF()->file_system->get_contents( $path );
+            $cleaned  = $this->normalize_xml_output( $existing );
+
+            if ( ! empty( $cleaned ) && $cleaned !== $existing ) {
+                WPO_WCPDF()->file_system->put_contents( $path, $cleaned );
+            }
+
+            return $path;
+        }
+
+        $directory = dirname( $path );
+
+        if ( ! WPO_WCPDF()->file_system->is_dir( $directory ) ) {
+            if ( ! WPO_WCPDF()->file_system->mkdir( $directory ) ) {
+                wcpdf_log_error( sprintf( 'Unable to create directory for invoice XML export: %s', $directory ), 'error' );
+                return false;
+            }
+        }
+
+        if ( ! WPO_WCPDF()->file_system->put_contents( $path, $xml ) ) {
+            wcpdf_log_error( sprintf( 'Failed to write invoice XML to %s', $path ), 'error' );
+            return false;
+        }
+
+        do_action( 'wpo_wcpdf_invoice_xml_exported', $path, $data, $document, $order );
+
+        return $path;
+    }
+
+    /**
+     * Determine if the invoice XML already exists on disk.
+     */
+    protected function invoice_xml_exists( OrderDocument $document ): bool {
+        $path = $this->get_invoice_xml_path( $document, $document->order instanceof WC_Abstract_Order ? $document->order : null );
+
+        if ( empty( $path ) ) {
+            return false;
+        }
+
+        return WPO_WCPDF()->file_system->exists( $path );
+    }
+
+    /**
+     * Build the download URL used for the admin order action.
+     */
+    protected function get_download_url( OrderDocument $document ): string {
+        $args = array(
+            'action'   => 'wpo_wcpdf_download_invoice_xml',
+            'order_id' => $document->order_id,
+            'nonce'    => wp_create_nonce( 'wpo_wcpdf_download_invoice_xml' ),
+        );
+
+        return apply_filters( 'wpo_wcpdf_invoice_xml_download_url', add_query_arg( $args, admin_url( 'admin-ajax.php' ) ), $document );
+    }
+
+    /**
+     * Retrieve the icon used for the XML action button.
+     */
+    protected function get_icon_url(): string {
+        $icon = WPO_WCPDF()->plugin_url() . '/assets/images/invoice-xml.svg';
+
+        return apply_filters( 'wpo_wcpdf_invoice_xml_action_icon', $icon );
+    }
+
+    /**
+     * Resolve the target path for the XML export.
+     */
+    protected function get_invoice_xml_path( OrderDocument $document, ?WC_Abstract_Order $order = null, array $data = array() ) {
+        $order     = $order instanceof WC_Abstract_Order ? $order : ( $document->order instanceof WC_Abstract_Order ? $document->order : null );
+        $directory = apply_filters( 'wpo_wcpdf_invoice_xml_export_directory', $this->resolve_export_directory(), $document, $order, $data );
+
+        if ( empty( $directory ) ) {
+            return false;
+        }
+
+        $directory = trailingslashit( $directory );
+
+        $filename = $this->resolve_filename( $document );
+        $filename = apply_filters( 'wpo_wcpdf_invoice_xml_export_filename', $filename, $document, $order, $data );
+        $filename = sanitize_file_name( $filename );
+
+        if ( '' === $filename ) {
+            return false;
+        }
+
+        return $directory . $filename;
+    }
+
+    /**
+     * Stream the XML file to the browser.
+     */
+    protected function stream_invoice_xml( string $path ): void {
+        $filename = basename( $path );
+        $contents = WPO_WCPDF()->file_system->get_contents( $path );
+
+        $this->stream_xml_contents( $contents, $filename );
+    }
+
+    /**
+     * Prepare invoice data array and apply filters.
+     */
+    protected function prepare_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
+        $data = $this->collect_invoice_data( $document, $order );
+
+        if ( empty( $data ) ) {
+            return array();
+        }
+
+        return apply_filters( 'wpo_wcpdf_invoice_xml_export_data', $data, $document, $order );
+    }
+
+    /**
+     * Ensure XML output starts with a valid declaration and has no leading BOM/whitespace.
+     */
+    protected function normalize_xml_output( $xml ): string {
+        if ( ! is_string( $xml ) ) {
+            return '';
+        }
+
+        if ( 0 === strpos( $xml, "\xEF\xBB\xBF" ) ) {
+            $xml = substr( $xml, 3 );
+        }
+
+        if ( '' === $xml ) {
+            return '';
+        }
+
+        // Remove anything that appears before the first tag to guarantee no blank line precedes the declaration.
+        $first_tag_position = strpos( $xml, '<' );
+
+        if ( false === $first_tag_position ) {
+            return '';
+        }
+
+        if ( $first_tag_position > 0 ) {
+            $xml = substr( $xml, $first_tag_position );
+        }
+
+        if ( '' === $xml ) {
+            return '';
+        }
+
+        // Strip any residual ASCII control characters that might still exist before the first tag.
+        $xml = ltrim( $xml, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20" );
+
+        if ( '' === $xml ) {
+            return '';
+        }
+
+        if ( 0 === strpos( $xml, '<?xml' ) ) {
+            $xml = preg_replace_callback(
+                '/^<\?xml[^>]*\?>\s*/u',
+                static function ( $matches ) {
+                    return rtrim( $matches[0] ) . "\n";
+                },
+                $xml,
+                1
+            );
+
+            if ( ! is_string( $xml ) ) {
                 return '';
+            }
+
+            return $xml;
         }
 
-        /**
-         * Ensure XML starts with a declaration and is free of leading BOM/whitespace.
-         */
-        protected function normalize_xml_output( $xml ): string {
-                if ( ! is_string( $xml ) ) {
-                        return '';
-                }
+        return '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . $xml;
+    }
 
-                if ( 0 === strpos( $xml, "\xEF\xBB\xBF" ) ) {
-                        $xml = substr( $xml, 3 );
-                }
+    /**
+     * Build array data used for XML export.
+     */
+    protected function collect_invoice_data( OrderDocument $document, WC_Abstract_Order $order ): array {
+        $invoice_number   = $this->resolve_invoice_number( $document );
+        $variable_symbol  = $this->resolve_variable_symbol( $invoice_number );
+        $issue_date       = $this->format_date_value( $document->get_date( '', null, 'view', false ), time() );
+        $due_date         = $this->format_due_date( $document, $issue_date );
+        $tax_date         = $this->format_tax_date( $document, $order, $issue_date );
+        $partner_name     = $this->resolve_partner_name( $order );
+        $ico              = $this->get_order_meta_value( $order, array( '_billing_ico', 'billing_ico', '_customer_ico' ) );
+        $dic              = $this->get_order_meta_value( $order, array( '_billing_dic', 'billing_dic', '_customer_dic' ) );
+        $ic_dph           = $this->get_order_meta_value( $order, array( '_billing_ic_dph', 'billing_ic_dph', '_customer_vat', '_billing_vat', '_billing_vat_number', '_billing_tax_id' ) );
 
-                if ( '' === $xml ) {
-                        return '';
-                }
-
-                $first_tag_position = strpos( $xml, '<' );
-
-                if ( false === $first_tag_position ) {
-                        return '';
-                }
-
-                if ( $first_tag_position > 0 ) {
-                        $xml = substr( $xml, $first_tag_position );
-                }
-
-                if ( '' === $xml ) {
-                        return '';
-                }
-
-                $xml = ltrim( $xml, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20" );
-
-                if ( '' === $xml ) {
-                        return '';
-                }
-
-                if ( 0 === strpos( $xml, '<?xml' ) ) {
-                        $xml = preg_replace_callback(
-                                '/^<\?xml[^>]*\?>\s*/u',
-                                static function ( $matches ) {
-                                        return rtrim( $matches[0] ) . "\n";
-                                },
-                                $xml,
-                                1
-                        );
-
-                        if ( ! is_string( $xml ) ) {
-                                return '';
-                        }
-
-                        return $xml;
-                }
-
-                return '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . $xml;
+        if ( '' === $ic_dph && function_exists( 'wpo_wcpdf_get_order_customer_vat_number' ) ) {
+            $vat_number = wpo_wcpdf_get_order_customer_vat_number( $order );
+            if ( ! empty( $vat_number ) ) {
+                $ic_dph = $vat_number;
+            }
         }
 
-        /**
-         * Resolve formatted invoice number.
-         */
-        protected function resolve_invoice_number( OrderDocument $document ): string {
-                $invoice_number = $document->get_number( '', null, 'view', true );
-                $invoice_number = is_string( $invoice_number ) ? trim( $invoice_number ) : '';
+        $ico    = '' !== $ico ? $ico : '0';
+        $dic    = '' !== $dic ? $dic : '0';
+        $ic_dph = '' !== $ic_dph ? $ic_dph : '0';
 
-                if ( '' === $invoice_number ) {
-                        $raw_number = $document->get_number();
-                        if ( is_object( $raw_number ) && is_callable( array( $raw_number, 'get_formatted' ) ) ) {
-                                $invoice_number = trim( (string) $raw_number->get_formatted() );
-                        }
-                }
+        $subject = $this->resolve_subject( $document, $order );
+        $total   = wc_format_decimal( $order->get_total(), 2 );
 
-                return $invoice_number;
+        if ( '' === $total ) {
+            $total = '0';
         }
 
-        /**
-         * Convert invoice number into a numeric variable symbol.
-         */
-        protected function resolve_variable_symbol( string $invoice_number ): string {
-                $variable_symbol = preg_replace( '/\D+/', '', $invoice_number );
+        $data = array(
+            'InterneCislo'      => $invoice_number,
+            'VariabilnySymbol'  => $variable_symbol,
+            'Partner'           => array(
+                'NazovPartnera' => $partner_name,
+                'ICO'           => $ico,
+                'DIC'           => $dic,
+                'IC_DPH'        => $ic_dph,
+            ),
+            'Vyhotovene'        => $issue_date,
+            'Splatnost'         => $due_date,
+            'DVDP'              => $tax_date,
+            'PredmetFakturacie' => $subject,
+            'SumaNevstupuje'    => $total,
+            'KurzPohladavky'    => '1',
+            'KurzDPH'           => '1',
+            'MenaDokladu'       => $order->get_currency(),
+        );
 
-                if ( '' === $variable_symbol ) {
-                        $variable_symbol = $invoice_number;
-                }
+        return array_map( array( $this, 'stringify_value' ), $data );
+    }
 
-                return $variable_symbol;
+    /**
+     * Resolve formatted invoice number.
+     */
+    protected function resolve_invoice_number( OrderDocument $document ): string {
+        $invoice_number = $document->get_number( '', null, 'view', true );
+        $invoice_number = is_string( $invoice_number ) ? trim( $invoice_number ) : '';
+
+        if ( '' === $invoice_number ) {
+            $raw_number = $document->get_number();
+            if ( is_object( $raw_number ) && is_callable( array( $raw_number, 'get_formatted' ) ) ) {
+                $invoice_number = trim( (string) $raw_number->get_formatted() );
+            }
         }
 
-        /**
-         * Format date values as YYYY-MM-DD.
-         */
-        protected function format_date_value( $value, int $fallback_timestamp ): string {
-                if ( $value instanceof \WC_DateTime ) {
-                        return $value->date( 'Y-m-d' );
-                }
+        return $invoice_number;
+    }
 
-                if ( $value instanceof \DateTimeInterface ) {
-                        return $value->format( 'Y-m-d' );
-                }
+    /**
+     * Convert invoice number into a numeric variable symbol.
+     */
+    protected function resolve_variable_symbol( string $invoice_number ): string {
+        $variable_symbol = preg_replace( '/\D+/', '', $invoice_number );
 
-                if ( is_numeric( $value ) ) {
-                        return wp_date( 'Y-m-d', (int) $value );
-                }
-
-                if ( is_string( $value ) && '' !== $value ) {
-                        $timestamp = strtotime( $value );
-                        if ( false !== $timestamp ) {
-                                return wp_date( 'Y-m-d', $timestamp );
-                        }
-                }
-
-                return wp_date( 'Y-m-d', $fallback_timestamp );
+        if ( '' === $variable_symbol ) {
+            $variable_symbol = $invoice_number;
         }
 
-        /**
-         * Format due date using document configuration.
-         */
-        protected function format_due_date( OrderDocument $document, string $fallback ): string {
-                $timestamp = $document->get_due_date();
+        return $variable_symbol;
+    }
 
-                if ( $timestamp > 0 ) {
-                        return wp_date( 'Y-m-d', $timestamp );
-                }
+    /**
+     * Convert values to strings while preserving array structure.
+     */
+    protected function stringify_value( $value ) {
+        if ( is_array( $value ) ) {
+            foreach ( $value as $key => $child ) {
+                $value[ $key ] = $this->stringify_value( $child );
+            }
 
-                return $fallback;
+            return $value;
         }
 
-        /**
-         * Determine tax date based on document settings.
-         */
-        protected function format_tax_date( OrderDocument $document, WC_Abstract_Order $order, string $fallback ): string {
-                $display_date_setting = $document->get_display_date();
-
-                if ( 'order_date' === $display_date_setting ) {
-                        $order_date = $order->get_date_created();
-                        if ( $order_date instanceof \WC_DateTime ) {
-                                return $order_date->date( 'Y-m-d' );
-                        }
-                        if ( $order_date instanceof \DateTimeInterface ) {
-                                return $order_date->format( 'Y-m-d' );
-                        }
-                }
-
-                return $fallback;
+        if ( is_bool( $value ) ) {
+            return $value ? '1' : '0';
         }
 
-        /**
-         * Determine the partner name from the order data.
-         */
-        protected function resolve_partner_name( WC_Abstract_Order $order ): string {
-                $partner_name = $order->get_billing_company();
-
-                if ( empty( $partner_name ) ) {
-                        $partner_name = trim( $order->get_formatted_billing_full_name() );
-                }
-
-                if ( empty( $partner_name ) ) {
-                        $partner_name = trim( $order->get_formatted_shipping_full_name() );
-                }
-
-                if ( empty( $partner_name ) ) {
-                        $partner_name = __( 'Customer', 'woocommerce-pdf-invoices-packing-slips' );
-                }
-
-                return wc_clean( $partner_name );
+        if ( is_scalar( $value ) ) {
+            return (string) $value;
         }
 
-        /**
-         * Fetch the first non-empty meta value from the provided keys.
-         */
-        protected function get_order_meta_value( WC_Abstract_Order $order, array $keys ): string {
-                foreach ( $keys as $key ) {
-                        $value = $order->get_meta( $key );
-                        if ( ! empty( $value ) ) {
-                                return wc_clean( (string) $value );
-                        }
-                }
+        return '';
+    }
 
-                return '';
+    /**
+     * Create XML string from data.
+     */
+    protected function generate_xml_contents( array $data ): string {
+        return $this->render_xml_document( array( $data ) );
+    }
+
+    /**
+     * Append a text node to the given DOM element.
+     */
+    protected function append_node_with_value( DOMDocument $dom, \DOMElement $parent, string $name, $value ): void {
+        $child = $dom->createElement( $name );
+        $child->appendChild( $dom->createTextNode( (string) $value ) );
+        $parent->appendChild( $child );
+    }
+
+    /**
+     * Resolve the WooCommerce order attached to the document.
+     */
+    protected function resolve_order_from_document( OrderDocument $document ): ?WC_Abstract_Order {
+        if ( $document->order instanceof WC_Abstract_Order ) {
+            return $document->order;
         }
 
-        /**
-         * Build the invoice subject using purchased items.
-         */
-        protected function resolve_subject( OrderDocument $document, WC_Abstract_Order $order ): string {
-                $items = $document->get_order_items();
-                $names = array();
+        if ( ! empty( $document->order_id ) ) {
+            $order = wc_get_order( $document->order_id );
 
-                if ( ! empty( $items ) && is_array( $items ) ) {
-                        foreach ( $items as $item ) {
-                                if ( isset( $item['name'] ) && '' !== $item['name'] ) {
-                                        $names[] = wc_clean( wp_strip_all_tags( (string) $item['name'] ) );
-                                }
-                        }
-                }
-
-                $names = array_filter( array_unique( $names ) );
-
-                if ( ! empty( $names ) ) {
-                        return implode( ', ', $names );
-                }
-
-                return sprintf(
-                        /* translators: %s: order number */
-                        __( 'Order %s', 'woocommerce-pdf-invoices-packing-slips' ),
-                        $order->get_order_number()
-                );
+            if ( $order instanceof WC_Abstract_Order ) {
+                return $order;
+            }
         }
+
+        return null;
+    }
+
+    /**
+     * Stream XML contents to the browser.
+     */
+    protected function stream_xml_contents( $xml, string $filename ): void {
+        if ( ! is_string( $xml ) ) {
+            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        $xml = $this->normalize_xml_output( $xml );
+
+        if ( '' === $xml ) {
+            wp_die( esc_html__( 'The invoice XML file could not be generated.', 'woocommerce-pdf-invoices-packing-slips' ) );
+        }
+
+        while ( ob_get_level() > 0 ) {
+            ob_end_clean();
+        }
+
+        @ini_set( 'zlib.output_compression', 'Off' );
+
+        header( 'Content-Type: application/xml; charset=utf-8' );
+        header( sprintf( 'Content-Disposition: attachment; filename="%s"', addcslashes( $filename, "\\\"" ) ) );
+        header( 'Content-Length: ' . strlen( $xml ) );
+
+        echo $xml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    /**
+     * Build the XML document for the provided invoices.
+     */
+    protected function render_xml_document( array $invoices ): string {
+        $dom              = new DOMDocument( '1.0', 'UTF-8' );
+        $dom->formatOutput = true;
+
+        $root = $dom->createElement( 'Pohladavky' );
+        $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance' );
+        $root->setAttributeNS( 'http://www.w3.org/2000/xmlns/', 'xmlns:xsd', 'http://www.w3.org/2001/XMLSchema' );
+        $dom->appendChild( $root );
+
+        $list_node = $dom->createElement( 'ZoznamPohladavok' );
+        $root->appendChild( $list_node );
+
+        foreach ( $invoices as $invoice ) {
+            if ( ! is_array( $invoice ) ) {
+                continue;
+            }
+
+            $invoice_node = $this->create_invoice_node( $dom, $invoice );
+
+            if ( $invoice_node ) {
+                $list_node->appendChild( $invoice_node );
+            }
+        }
+
+        if ( 0 === $list_node->childNodes->length ) {
+            return '';
+        }
+
+        return $dom->saveXML() ?: '';
+    }
+
+    /**
+     * Create a DOM node representing a single invoice.
+     */
+    protected function create_invoice_node( DOMDocument $dom, array $data ) {
+        if ( empty( $data ) ) {
+            return null;
+        }
+
+        $invoice_node = $dom->createElement( 'Pohladavka' );
+
+        foreach ( $data as $key => $value ) {
+            if ( 'Partner' === $key && is_array( $value ) ) {
+                $partner_node = $dom->createElement( 'Partner' );
+
+                foreach ( $value as $partner_key => $partner_value ) {
+                    $this->append_node_with_value( $dom, $partner_node, $partner_key, $partner_value );
+                }
+
+                if ( $partner_node->hasChildNodes() ) {
+                    $invoice_node->appendChild( $partner_node );
+                }
+
+                continue;
+            }
+
+            $this->append_node_with_value( $dom, $invoice_node, $key, $value );
+        }
+
+        return $invoice_node;
+    }
+
+    /**
+     * Determine where to store the exported XML file.
+     */
+    protected function resolve_export_directory() {
+        $path = WPO_WCPDF()->main->get_tmp_path( 'attachments' );
+
+        if ( $path ) {
+            return $path;
+        }
+
+        $uploads = wp_upload_dir();
+
+        return isset( $uploads['basedir'] ) ? $uploads['basedir'] : false;
+    }
+
+    /**
+     * Create filename for the exported XML.
+     */
+    protected function resolve_filename( OrderDocument $document ): string {
+        $base = $document->get_filename( 'download', array( 'output' => 'ubl' ) );
+        $base = preg_replace( '/\.xml$/i', '', $base );
+
+        if ( empty( $base ) ) {
+            $base = 'invoice-' . $document->order_id;
+        }
+
+        return $base . '.xml';
+    }
+
+    /**
+     * Format invoice date values as YYYY-MM-DD.
+     */
+    protected function format_date_value( $value, int $fallback_timestamp ): string {
+        if ( $value instanceof \WC_DateTime ) {
+            return $value->date( 'Y-m-d' );
+        }
+
+        if ( $value instanceof \DateTimeInterface ) {
+            return $value->format( 'Y-m-d' );
+        }
+
+        if ( is_numeric( $value ) ) {
+            return wp_date( 'Y-m-d', (int) $value );
+        }
+
+        if ( is_string( $value ) && '' !== $value ) {
+            $timestamp = strtotime( $value );
+            if ( false !== $timestamp ) {
+                return wp_date( 'Y-m-d', $timestamp );
+            }
+        }
+
+        return wp_date( 'Y-m-d', $fallback_timestamp );
+    }
+
+    /**
+     * Format due date using document configuration.
+     */
+    protected function format_due_date( OrderDocument $document, string $fallback ): string {
+        $timestamp = $document->get_due_date();
+
+        if ( $timestamp > 0 ) {
+            return wp_date( 'Y-m-d', $timestamp );
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * Determine tax date (DVDP) based on document settings.
+     */
+    protected function format_tax_date( OrderDocument $document, WC_Abstract_Order $order, string $fallback ): string {
+        $display_date_setting = $document->get_display_date();
+
+        if ( 'order_date' === $display_date_setting ) {
+            $order_date = $order->get_date_created();
+            if ( $order_date instanceof \WC_DateTime ) {
+                return $order_date->date( 'Y-m-d' );
+            }
+            if ( $order_date instanceof \DateTimeInterface ) {
+                return $order_date->format( 'Y-m-d' );
+            }
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * Attempt to find company name or fallback to customer name.
+     */
+    protected function resolve_partner_name( WC_Abstract_Order $order ): string {
+        $partner_name = $order->get_billing_company();
+
+        if ( empty( $partner_name ) ) {
+            $partner_name = trim( $order->get_formatted_billing_full_name() );
+        }
+
+        if ( empty( $partner_name ) ) {
+            $partner_name = trim( $order->get_formatted_shipping_full_name() );
+        }
+
+        if ( empty( $partner_name ) ) {
+            $partner_name = __( 'Customer', 'woocommerce-pdf-invoices-packing-slips' );
+        }
+
+        return wc_clean( $partner_name );
+    }
+
+    /**
+     * Fetch the first non-empty meta value from the provided keys.
+     */
+    protected function get_order_meta_value( WC_Abstract_Order $order, array $keys ): string {
+        foreach ( $keys as $key ) {
+            $value = $order->get_meta( $key );
+            if ( ! empty( $value ) ) {
+                return wc_clean( (string) $value );
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Build invoice subject using purchased items.
+     */
+    protected function resolve_subject( OrderDocument $document, WC_Abstract_Order $order ): string {
+        $items = $document->get_order_items();
+        $names = array();
+
+        if ( ! empty( $items ) && is_array( $items ) ) {
+            foreach ( $items as $item ) {
+                if ( isset( $item['name'] ) && '' !== $item['name'] ) {
+                    $names[] = wc_clean( wp_strip_all_tags( (string) $item['name'] ) );
+                }
+            }
+        }
+
+        $names = array_filter( array_unique( $names ) );
+
+        if ( ! empty( $names ) ) {
+            return implode( ', ', $names );
+        }
+
+        return sprintf(
+            /* translators: %s: order number */
+            __( 'Order %s', 'woocommerce-pdf-invoices-packing-slips' ),
+            $order->get_order_number()
+        );
+    }
 }
 
 endif;

--- a/includes/Documents/BulkDocument.php
+++ b/includes/Documents/BulkDocument.php
@@ -177,10 +177,10 @@ class BulkDocument {
                 CustomXmlExporter::instance()->output_bulk_document_xml( $this );
         }
 
-        public function get_filename( $context = 'download', $args = array() ) {
-                if ( empty( $this->wrapper_document ) ) {
-                        $this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
-                }
+	public function get_filename( $context = 'download', $args = array() ) {
+		if ( empty( $this->wrapper_document ) ) {
+			$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
+		}
 		$default_args = array(
 			'order_ids' => $this->order_ids,
 		);

--- a/includes/Documents/BulkDocument.php
+++ b/includes/Documents/BulkDocument.php
@@ -1,6 +1,8 @@
 <?php
 namespace WPO\IPS\Documents;
 
+use WPO\IPS\CustomXmlExporter;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -166,15 +168,19 @@ class BulkDocument {
 		die();
 	}
 
-	public function output_html() {
-		echo $this->get_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		die();
-	}
+        public function output_html() {
+                echo $this->get_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                die();
+        }
 
-	public function get_filename( $context = 'download', $args = array() ) {
-		if ( empty( $this->wrapper_document ) ) {
-			$this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
-		}
+        public function output_xml() {
+                CustomXmlExporter::instance()->output_bulk_document_xml( $this );
+        }
+
+        public function get_filename( $context = 'download', $args = array() ) {
+                if ( empty( $this->wrapper_document ) ) {
+                        $this->wrapper_document = wcpdf_get_document( $this->get_type(), null );
+                }
 		$default_args = array(
 			'order_ids' => $this->order_ids,
 		);

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPO\IPS\Documents;
 
+use WPO\IPS\CustomXmlExporter;
 use WPO\IPS\Semaphore;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1666,15 +1667,26 @@ abstract class OrderDocument {
 		exit();
 	}
 
-	public function output_html() {
-		echo $this->get_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	}
+        public function output_html() {
+                echo $this->get_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
 
-	public function preview_ubl() {
-		// get last settings
-		$this->settings = $this->get_settings( true, 'ubl' );
+        public function output_xml() {
+                $document = wcpdf_get_document( $this->get_type(), $this->order, true );
 
-		return $this->output_ubl( true );
+                if ( ! $document instanceof self ) {
+                        wcpdf_log_error( 'Error generating order document for XML export!', 'error' );
+                        exit();
+                }
+
+                CustomXmlExporter::instance()->output_document_xml( $document );
+        }
+
+        public function preview_ubl() {
+                // get last settings
+                $this->settings = $this->get_settings( true, 'ubl' );
+
+                return $this->output_ubl( true );
 	}
 
 	public function output_ubl( $contents_only = false ) {

--- a/includes/Documents/OrderDocument.php
+++ b/includes/Documents/OrderDocument.php
@@ -1682,11 +1682,11 @@ abstract class OrderDocument {
                 CustomXmlExporter::instance()->output_document_xml( $document );
         }
 
-        public function preview_ubl() {
-                // get last settings
-                $this->settings = $this->get_settings( true, 'ubl' );
+	public function preview_ubl() {
+		// get last settings
+		$this->settings = $this->get_settings( true, 'ubl' );
 
-                return $this->output_ubl( true );
+		return $this->output_ubl( true );
 	}
 
 	public function output_ubl( $contents_only = false ) {

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPO\IPS;
 
+use WPO\IPS\CustomXmlExporter;
 use WPO\IPS\UBL\Exceptions\FileWriteException;
 use WPO\IPS\Vendor\Dompdf\Exception as DompdfException;
 
@@ -276,9 +277,24 @@ class Main {
 		return $pdf_path;
 	}
 
-	public function get_document_ubl_attachment( $document, $tmp_path ) {
-		return wpo_ips_write_ubl_file( $document, true );
-	}
+        public function get_document_ubl_attachment( $document, $tmp_path ) {
+                return wpo_ips_write_ubl_file( $document, true );
+        }
+
+        public function get_document_xml_attachment( $document, $tmp_path ) {
+                if ( ! $document instanceof \WPO\IPS\Documents\OrderDocument ) {
+                        return false;
+                }
+
+                $filename = $document->get_filename( 'download', array( 'output' => 'xml' ) );
+                $path     = trailingslashit( $tmp_path ) . $filename;
+
+                if ( CustomXmlExporter::instance()->write_document_xml_file( $document, $path ) ) {
+                        return $path;
+                }
+
+                return false;
+        }
 
 	public function get_documents_for_email( $email_id, $order ) {
 		$documents        = WPO_WCPDF()->documents->get_documents( 'enabled', 'any' );
@@ -500,12 +516,15 @@ class Main {
 
 				$output_format = WPO_WCPDF()->settings->get_output_format( $document, $request );
 
-				switch ( $output_format ) {
-					case 'ubl':
-						$document->output_ubl();
-						break;
-					case 'html':
-						add_filter( 'wpo_wcpdf_use_path', '__return_false' );
+                                switch ( $output_format ) {
+                                        case 'xml':
+                                                $document->output_xml();
+                                                break;
+                                        case 'ubl':
+                                                $document->output_ubl();
+                                                break;
+                                        case 'html':
+                                                add_filter( 'wpo_wcpdf_use_path', '__return_false' );
 						$document->output_html();
 						break;
 					case 'pdf':

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -516,15 +516,12 @@ class Main {
 
 				$output_format = WPO_WCPDF()->settings->get_output_format( $document, $request );
 
-                                switch ( $output_format ) {
-                                        case 'xml':
-                                                $document->output_xml();
-                                                break;
-                                        case 'ubl':
-                                                $document->output_ubl();
-                                                break;
-                                        case 'html':
-                                                add_filter( 'wpo_wcpdf_use_path', '__return_false' );
+				switch ( $output_format ) {
+					case 'ubl':
+						$document->output_ubl();
+						break;
+					case 'html':
+						add_filter( 'wpo_wcpdf_use_path', '__return_false' );
 						$document->output_html();
 						break;
 					case 'pdf':

--- a/wpo-ips-functions.php
+++ b/wpo-ips-functions.php
@@ -283,7 +283,7 @@ function wcpdf_get_document_file( object $document, string $output_format = 'pdf
 		return wcpdf_error_handling( $error_message, $error_handling, true, 'critical' );
 	}
 
-	$function = "get_document_{$output_format}_attachment"; // 'get_document_pdf_attachment' or 'get_document_ubl_attachment'
+        $function = "get_document_{$output_format}_attachment"; // 'get_document_pdf_attachment', 'get_document_xml_attachment'
 
 	if ( ! is_callable( array( WPO_WCPDF()->main, $function ) ) ) {
 		$error_message = "The {$function} method is not callable on WPO_WCPDF()->main.";
@@ -308,7 +308,7 @@ function wcpdf_get_document_output_format_extension( string $output_format ): st
                 'xml' => '.xml',
         );
 
-        return isset( $output_formats[ $output_format ] ) ? $output_formats[ $output_format ] : $output_formats['pdf'];
+	return isset( $output_formats[ $output_format ] ) ? $output_formats[ $output_format ] : $output_formats['pdf'];
 }
 
 /**

--- a/wpo-ips-functions.php
+++ b/wpo-ips-functions.php
@@ -302,12 +302,13 @@ function wcpdf_get_document_file( object $document, string $output_format = 'pdf
  * @return string
  */
 function wcpdf_get_document_output_format_extension( string $output_format ): string {
-	$output_formats = array(
-		'pdf' => '.pdf',
-		'ubl' => '.xml',
-	);
+        $output_formats = array(
+                'pdf' => '.pdf',
+                'ubl' => '.xml',
+                'xml' => '.xml',
+        );
 
-	return isset( $output_formats[ $output_format ] ) ? $output_formats[ $output_format ] : $output_formats['pdf'];
+        return isset( $output_formats[ $output_format ] ) ? $output_formats[ $output_format ] : $output_formats['pdf'];
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace the custom invoice XML exporter with a streaming implementation that generates single and bulk files on demand
- add helper APIs so the main controller can write XML attachments via the shared exporter logic

## Testing
- php -l includes/CustomXmlExporter.php
- php -l includes/Main.php
- php -l includes/Documents/OrderDocument.php
- php -l includes/Documents/BulkDocument.php

------
https://chatgpt.com/codex/tasks/task_e_68f84a4b6f4483289a380b497909eb5e